### PR TITLE
Fixed Adding Device Method - probably typo.

### DIFF
--- a/fritz-box-connect.groovy
+++ b/fritz-box-connect.groovy
@@ -108,7 +108,7 @@ def addDevices() {
 		def d
         
 		if (selectedDevice) {
-        	d = getChildDevices(selectedDevice.key)
+        	d = getChildDevice(selectedDevice.key)
         }
         
         if (!d) {


### PR DESCRIPTION
Seems that there was a typo in the addDevices Method that prohibited the addition of new devices